### PR TITLE
Add translation for connection failure sensor

### DIFF
--- a/custom_components/amt8000/binary_sensor.py
+++ b/custom_components/amt8000/binary_sensor.py
@@ -66,16 +66,15 @@ class AmtConnectionFailureSensor(CoordinatorEntity, BinarySensorEntity):
         """Initialize the connection failure sensor."""
         super().__init__(coordinator)
         self._attr_device_class = BinarySensorDeviceClass.PROBLEM
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "connection_failure"
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Update the stored value on coordinator updates."""
         self.async_write_ha_state()
 
-    @property
-    def name(self) -> str:
-        """Return the name of the entity."""
-        return "AMT-8000 Falha na Conexão"
+
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/amt8000/strings.json
+++ b/custom_components/amt8000/strings.json
@@ -27,5 +27,12 @@
         }
       }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "connection_failure": {
+        "name": "Falha na Conexão"
+      }
+    }
   }
 }

--- a/custom_components/amt8000/translations/en.json
+++ b/custom_components/amt8000/translations/en.json
@@ -27,5 +27,12 @@
                 }
             }
         }
+    },
+    "entity": {
+        "binary_sensor": {
+            "connection_failure": {
+                "name": "Connection Failure"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add translation strings for the connection failure binary sensor
- use `self.translation_key` for the connection failure name

## Testing
- `python -m py_compile custom_components/amt8000/*.py`
- `ruff check custom_components/amt8000` *(fails: E722, F401)*

------
https://chatgpt.com/codex/tasks/task_e_684d559545a8832a9c903fdac14b8b13