### PR TITLE
Handle initial connection failure

### DIFF
--- a/custom_components/amt8000/alarm_control_panel.py
+++ b/custom_components/amt8000/alarm_control_panel.py
@@ -48,7 +48,8 @@ async def async_setup_entry(
         hass.data[coordinator_key] = coordinator
     except Exception as e:
         LOGGER.error(f"Failed to initialize coordinator: {e}")
-        raise
+        hass.data[coordinator_key] = coordinator
+        coordinator.connection_failed = True
     
     LOGGER.info('Setting up 5 alarm control panels (partitions 1-5)...')
     

--- a/custom_components/amt8000/binary_sensor.py
+++ b/custom_components/amt8000/binary_sensor.py
@@ -44,7 +44,8 @@ async def async_setup_entry(
             hass.data[coordinator_key] = coordinator
         except Exception as e:
             LOGGER.error(f"Failed to initialize coordinator: {e}")
-            raise
+            hass.data[coordinator_key] = coordinator
+            coordinator.connection_failed = True
     else:
         LOGGER.info("Reusing existing coordinator for binary sensors")
         coordinator = hass.data[coordinator_key]

--- a/custom_components/amt8000/sensor.py
+++ b/custom_components/amt8000/sensor.py
@@ -43,7 +43,8 @@ async def async_setup_entry(
             hass.data[coordinator_key] = coordinator
         except Exception as e:
             LOGGER.error(f"Failed to initialize coordinator: {e}")
-            raise
+            hass.data[coordinator_key] = coordinator
+            coordinator.connection_failed = True
     else:
         LOGGER.info("Reusing existing coordinator for zone sensors")
         coordinator = hass.data[coordinator_key]


### PR DESCRIPTION
## Summary
- handle initial connection failure in `async_setup_entry`

## Testing
- `python -m py_compile custom_components/amt8000/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684d59c91fc8832a97fe5a98bfae350b